### PR TITLE
Allocate atlas SRV handles on first frame

### DIFF
--- a/Core/SDFGI.cpp
+++ b/Core/SDFGI.cpp
@@ -320,6 +320,14 @@ namespace SDFGI {
 
     void SDFGIManager::UpdateProbes(GraphicsContext& context) {
 
+        if (!externalDescAllocated) {
+            irradianceAtlasSRVHandle = externalHeap->Alloc(1);
+        }
+
+        if (!externalDescAllocated) {
+            depthAtlasSRVHandle = externalHeap->Alloc(1);
+        }
+
         if (updateTimer > 3) {
             updateTimer = 0;
         }
@@ -408,9 +416,6 @@ namespace SDFGI {
         computeContext.TransitionResource(irradianceAtlas, D3D12_RESOURCE_STATE_GENERIC_READ);
         computeContext.TransitionResource(depthAtlas, D3D12_RESOURCE_STATE_GENERIC_READ);
 
-        if (!externalDescAllocated) {
-            irradianceAtlasSRVHandle = externalHeap->Alloc(1);
-        }
         uint32_t DestCount = 1;
         uint32_t SourceCounts[] = { 1 };
         D3D12_CPU_DESCRIPTOR_HANDLE SourceTextures[] =
@@ -419,9 +424,6 @@ namespace SDFGI {
         };
         g_Device->CopyDescriptors(1, &irradianceAtlasSRVHandle, &DestCount, DestCount, SourceTextures, SourceCounts, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-        if (!externalDescAllocated) {
-            depthAtlasSRVHandle = externalHeap->Alloc(1);
-        }
         D3D12_CPU_DESCRIPTOR_HANDLE DepthSourceTextures[] =
         {
              depthAtlas.GetSRV()


### PR DESCRIPTION
Fix a null exception crash that is only happening on my machine... but probably should do this anyway. 